### PR TITLE
1d amr examples

### DIFF
--- a/examples/acoustics_1d_heterogeneous/setplot.py
+++ b/examples/acoustics_1d_heterogeneous/setplot.py
@@ -1,79 +1,51 @@
-def setplot(plotdata):
+from __future__ import absolute_import
+
+#--------------------------
+def setplot(plotdata=None):
+#--------------------------
     
+    """ 
+    Specify what is to be plotted at each frame.
+    Input:  plotdata, an instance of clawpack.visclaw.data.ClawPlotData.
+    Output: a modified version of plotdata.
+    
+    """ 
+
+    if plotdata is None:
+        from clawpack.visclaw.data import ClawPlotData
+        plotdata = ClawPlotData()
+
     plotdata.clearfigures()
+
+    # Figures corresponding to Figure 9.5 of LeVeque, "Finite Volume
+    # Methods for Hyperbolic Problems," 2002 (though more of them)
 
     # Tuples of (variable name, variable number)
     figdata = [('Pressure', 0),
                ('Velocity', 1)]
 
-    # Draw a vertical dashed line at the interface
+    # Afteraxes function: draw a vertical dashed line at the interface
     # between different media
     def draw_interface(current_data):
         import pylab
         pylab.plot([0., 0.], [-1000., 1000.], 'k--')
-    
-    # Formatting title
-    def format(current_data, var, adjoint):
-        import pylab
-        size = 28
-        t = current_data.t
-        timestr = float(t)
-        
-        if (var == 0):
-            titlestr = 'Pressure at time %s' % timestr
-        else:
-            titlestr = 'Velocity at time %s' % timestr
-        
-        pylab.title(titlestr, fontsize=size)
-        pylab.xticks(fontsize=size)
-        pylab.yticks(fontsize=size)
-        pylab.xticks([-4, -2, 0, 2], fontsize=size)
-    
-    # After axis function for pressure
-    def aa_pressure(current_data):
-        draw_interface(current_data)
-        format(current_data, 0, False)
-
-    # After axis function for velocity
-    def aa_velocity(current_data):
-        draw_interface(current_data)
-        format(current_data, 1, False)
 
     for varname, varid in figdata:
         plotfigure = plotdata.new_plotfigure(name=varname, figno=varid)
-        plotfigure.kwargs = {'figsize': (11,5)}
-
+        plotfigure.kwargs = {'figsize':(12,6)}
+        
         plotaxes = plotfigure.new_plotaxes()
-        plotaxes.axescmd = 'axes([0.1,0.1,0.4,0.8])'
-        plotaxes.xlimits = [-5., 3.]
+        plotaxes.xlimits = [-5., 5.]
         plotaxes.ylimits = [-0.5, 1.5]    # Good for both vars because of near-unit impedance
-        if (varid == 0):
-            plotaxes.afteraxes = aa_pressure
-        else:
-            plotaxes.afteraxes = aa_velocity
+        plotaxes.title = varname
+        plotaxes.afteraxes = draw_interface
 
         plotitem = plotaxes.new_plotitem(plot_type='1d_plot')
         plotitem.plot_var = varid
-        plotitem.color = 'b'
-        plotitem.plotstyle = 'o'
-
-    #-----------------------------------------
-    # Figures for gauges
-    #-----------------------------------------
-    plotfigure = plotdata.new_plotfigure(name='q', figno=300, \
-                                     type='each_gauge')
-    plotfigure.clf_each_gauge = True
-    
-    plotaxes = plotfigure.new_plotaxes()
-    plotaxes.xlimits = 'auto'
-    plotaxes.ylimits = 'auto'
-    plotaxes.title = 'Pressure'
-    plotitem = plotaxes.new_plotitem(plot_type='1d_plot')
-    plotitem.plot_var = 0
-    plotitem.plotstyle = 'b-'
-    
-    # Parameters used only when creating html and/or latex hardcopy
-    # e.g., via clawpack.visclaw.frametools.printframes:
+        plotitem.amr_color = ['g','b','r']
+        plotitem.amr_plotstyle = ['^-','s-','o-']
+        plotitem.amr_data_show = [1,1,1]
+        plotitem.amr_kwargs = [{'markersize':8},{'markersize':6},{'markersize':5}]
 
     plotdata.printfigs = True          # Whether to output figures
     plotdata.print_format = 'png'      # What type of output format
@@ -83,3 +55,4 @@ def setplot(plotdata):
     plotdata.latex = False             # Whether to make LaTeX output
 
     return plotdata
+

--- a/examples/acoustics_1d_heterogeneous/setrun.py
+++ b/examples/acoustics_1d_heterogeneous/setrun.py
@@ -65,7 +65,7 @@ def setrun(claw_pkg='amrclaw'):
     clawdata.upper[0] = 3.           # xupper
     
     # Number of grid cells:
-    clawdata.num_cells[0] = 100      # mx
+    clawdata.num_cells[0] = 20       # mx
     
 
     # ---------------
@@ -260,8 +260,8 @@ def setrun(claw_pkg='amrclaw'):
     amrdata.amr_levels_max = 3
     
     # List of refinement ratios at each level (length at least amr_level_max-1)
-    amrdata.refinement_ratios_x = [2, 2]
-    amrdata.refinement_ratios_t = [2, 2]
+    amrdata.refinement_ratios_x = [4, 4]
+    amrdata.refinement_ratios_t = [4, 4]
     
     
     # Specify type of each aux variable in clawdata.auxtype.
@@ -276,7 +276,7 @@ def setrun(claw_pkg='amrclaw'):
     
     # Flag for refinement using routine flag2refine:
     amrdata.flag2refine = True      # use this?
-    amrdata.flag2refine_tol = 0.01 # tolerance used in this routine
+    amrdata.flag2refine_tol = 0.1 # tolerance used in this routine
     # User can modify flag2refine to change the criterion for flagging.
     # Default: check maximum absolute difference of first component of q
     # between a cell and each of its neighbors.

--- a/examples/acoustics_1d_homogeneous/setplot.py
+++ b/examples/acoustics_1d_homogeneous/setplot.py
@@ -23,7 +23,7 @@ def setplot(plotdata):
 
     # Figure for q[0]
     plotfigure = plotdata.new_plotfigure(name='Pressure and Velocity', figno=1)
-
+    plotfigure.kwargs = {'figsize': (8,8)}
     # Set up for axes in this figure:
     plotaxes = plotfigure.new_plotaxes()
     plotaxes.axescmd = 'subplot(2,1,1)'   # top figure
@@ -34,8 +34,11 @@ def setplot(plotdata):
     # Set up for item on these axes:
     plotitem = plotaxes.new_plotitem(plot_type='1d_plot')
     plotitem.plot_var = 0
-    plotitem.plotstyle = 'o'
-    plotitem.color = 'b'
+    plotitem.amr_color = ['g','b','r']
+    plotitem.amr_plotstyle = ['^-','s-','o-']
+    plotitem.amr_data_show = [1,1,1]
+    plotitem.amr_kwargs = [{'markersize':8},{'markersize':6},{'markersize':5}]
+
 
 
     # Figure for q[1]
@@ -50,8 +53,11 @@ def setplot(plotdata):
     # Set up for item on these axes:
     plotitem = plotaxes.new_plotitem(plot_type='1d_plot')
     plotitem.plot_var = 1
-    plotitem.plotstyle = 'o'
-    plotitem.color = 'b'
+    plotitem.amr_color = ['g','b','r']
+    plotitem.amr_plotstyle = ['^-','s-','o-']
+    plotitem.amr_data_show = [1,1,1]
+    plotitem.amr_kwargs = [{'markersize':8},{'markersize':6},{'markersize':5}]
+
     
     #-----------------------------------------
     # Figures for gauges

--- a/examples/advection_1d_example1/setplot.py
+++ b/examples/advection_1d_example1/setplot.py
@@ -53,7 +53,7 @@ def setplot(plotdata):
     plotitem = plotaxes.new_plotitem(plot_type='1d_plot')
     plotitem.plot_var = 0
     plotitem.amr_color = ['g','b','r']
-    plotitem.amr_plotstyle = ['^','s','o']
+    plotitem.amr_plotstyle = ['^-','s-','o-']
     plotitem.amr_data_show = [1,1,1]
     plotitem.amr_kwargs = [{'markersize':8},{'markersize':6},{'markersize':5}]
 
@@ -63,14 +63,14 @@ def setplot(plotdata):
         x = linspace(0,1,1000)
         t = current_data.t
         q = qtrue(x,t)
-        plot(x,q,'r',label='true solution')
+        plot(x,q,'k',label='true solution')
     
     def plot_qtrue_with_legend(current_data):
         from pylab import plot, legend
         x = linspace(0,1,1000)
         t = current_data.t
         q = qtrue(x,t)
-        plot(x,q,'r',label='true solution')
+        plot(x,q,'k',label='true solution')
         legend(loc='lower right')
 
     plotaxes.afteraxes = plot_qtrue_with_legend
@@ -94,7 +94,7 @@ def setplot(plotdata):
         plotitem = plotaxes.new_plotitem(plot_type='1d_plot')
         plotitem.plot_var = 0
         plotitem.amr_color = ['g','b','r']
-        plotitem.amr_plotstyle = ['^','s','o']
+        plotitem.amr_plotstyle = ['^-','s-','o-']
         plotitem.amr_data_show = [0,0,0]
         plotitem.amr_data_show[level-1] = 1  # show only one level
 

--- a/src/1d/amr1.f90
+++ b/src/1d/amr1.f90
@@ -104,7 +104,7 @@ program amr1
     integer :: i, iaux, mw, level
     integer :: ndim, nvar, naux, mcapa1, mindim
     integer :: nstart, nsteps, nv1, nx, lentotsave, num_gauge_SAVE
-    integer :: maxthreads
+    integer :: omp_get_max_threads, maxthreads
     real(kind=8) :: time, ratmet, cut, dtinit, dt_max
     logical :: vtime, rest, output_t0    
 

--- a/src/1d/gauges_module.f90
+++ b/src/1d/gauges_module.f90
@@ -347,8 +347,8 @@ contains
 
       implicit none
       integer :: gaugeNum,nvar,j,inum,k,idigit,ipos,myunit
+      integer :: omp_get_thread_num, mythread
       character*14 :: fileName
-      integer :: mythread
 
       ! open file for gauge gaugeNum, figure out name
       ! not writing gauge number since it is in file name now


### PR DESCRIPTION
@BrisaDavis:  I cleaned up setplot.py in the examples and fixed a couple routines so it compiles with OpenMP.

I ran into something curious in examples/acoustics_1d_heterogeneous when I changed to a coarse Level 1 grid and factor of 4 refinement.  It doesn't seem to de-refine where the solution is constant as I'd expect, even when I set the tolerance to 0.1.  If you make the coarsest level a bit finer, say 30 cells instead of only 20, it de-refines but then refines again where the solution is flat.

I haven't tried this in the other examples.